### PR TITLE
Fix small issues with worker placement

### DIFF
--- a/src/components/turn/DebugInfo.vue
+++ b/src/components/turn/DebugInfo.vue
@@ -6,14 +6,14 @@
       <b>actionCard</b>: {{actionCard}}<br/>
       <b>criteriaCard</b>: {{criteriaCard}}<br/>
     </p>
-    <table class="debug">
+    <table class="debug" v-if="navigationState.turn > 1">
       <tbody>
         <tr>
           <th v-for="bot of navigationState.botCount" :key="bot">Automa {{bot}}</th>
         </tr>
         <tr>
           <td v-for="bot of navigationState.botCount" :key="bot">
-            <ul v-if="navigationState.turn > 1">
+            <ul>
               <li v-for="turn in getBotPreviousTurns(bot).toReversed()" :key="turn.turn">
                 {{turn.turn}}: {{turn.action}} - {{turn.workerUsed}}w (act: {{turn.actionCard}}, crit: {{turn.criteriaCard}})
               </li>
@@ -73,12 +73,13 @@ export default defineComponent({
       const { round, turn, bot } = this.navigationState
       const turns = getPreviousTurns({state: this.state, round, turn, bot})
       return turns
-          .filter(turn => turn.bot == currentBot)
-          .map(turn => {
-            const actionCard = Cards.get(turn.actionCard ?? '')
-            const botActions = new BotActions(actionCard, round, turn.bot ?? 0, this.state)
-            return {round: turn.round, turn: turn.turn, bot: turn.bot ?? 0, actionCard: turn.actionCard, criteriaCard: turn.criteriaCard,
-                action: botActions.items[turn.action ?? 0]?.action, workerUsed: turn.workerUsed}
+          .filter(turnData => turnData.bot == currentBot)
+          .map(turnData => {
+            const actionCard = Cards.get(turnData.actionCard ?? '')
+            const botActions = new BotActions(actionCard, round, turnData.bot ?? 0, this.state)
+            return {round: turnData.round, turn: turnData.turn, bot: turnData.bot ?? 0,
+                actionCard: turnData.actionCard, criteriaCard: turnData.criteriaCard,
+                action: botActions.items[turnData.action ?? 0]?.action, workerUsed: turnData.workerUsed}
           })
     }
   }

--- a/src/components/turn/DebugInfo.vue
+++ b/src/components/turn/DebugInfo.vue
@@ -7,18 +7,20 @@
       <b>criteriaCard</b>: {{criteriaCard}}<br/>
     </p>
     <table class="debug">
-      <tr>
-        <th v-for="bot of navigationState.botCount" :key="bot">Automa {{bot}}</th>
-      </tr>
-      <tr>
-        <td v-for="bot of navigationState.botCount" :key="bot">
-          <ul v-if="navigationState.turn > 1">
-            <li v-for="turn in getBotPreviousTurns(bot).toReversed()" :key="turn.turn">
-              {{turn.turn}}: {{turn.action}} - {{turn.workerUsed}}w (act: {{turn.actionCard}}, crit: {{turn.criteriaCard}})
-            </li>
-          </ul>
-        </td>
-      </tr>
+      <tbody>
+        <tr>
+          <th v-for="bot of navigationState.botCount" :key="bot">Automa {{bot}}</th>
+        </tr>
+        <tr>
+          <td v-for="bot of navigationState.botCount" :key="bot">
+            <ul v-if="navigationState.turn > 1">
+              <li v-for="turn in getBotPreviousTurns(bot).toReversed()" :key="turn.turn">
+                {{turn.turn}}: {{turn.action}} - {{turn.workerUsed}}w (act: {{turn.actionCard}}, crit: {{turn.criteriaCard}})
+              </li>
+            </ul>
+          </td>
+        </tr>
+      </tbody>
     </table>
   </div>
 </template>
@@ -78,7 +80,6 @@ export default defineComponent({
             return {round: turn.round, turn: turn.turn, bot: turn.bot ?? 0, actionCard: turn.actionCard, criteriaCard: turn.criteriaCard,
                 action: botActions.items[turn.action ?? 0]?.action, workerUsed: turn.workerUsed}
           })
-      return []
     }
   }
 })

--- a/src/components/turn/DebugInfo.vue
+++ b/src/components/turn/DebugInfo.vue
@@ -68,16 +68,16 @@ export default defineComponent({
     }
   },
   methods: {
-    getBotPreviousTurns(currentBot: number) : {round: number, turn: number, bot: number, actionCard?: string, criteriaCard?: string,
+    getBotPreviousTurns(currentBot: number) : {round: number, turn: number, bot: number,
+          actionCard?: string, criteriaCard?: string,
           action?: Action, workerUsed?: number}[] {
       const { round, turn, bot } = this.navigationState
-      const turns = getPreviousTurns({state: this.state, round, turn, bot})
-      return turns
+      return getPreviousTurns({state: this.state, round, turn, bot})
           .filter(turnData => turnData.bot == currentBot)
           .map(turnData => {
             const actionCard = Cards.get(turnData.actionCard ?? '')
-            const botActions = new BotActions(actionCard, round, turnData.bot ?? 0, this.state)
-            return {round: turnData.round, turn: turnData.turn, bot: turnData.bot ?? 0,
+            const botActions = new BotActions(actionCard, round, currentBot, this.state)
+            return {round: turnData.round, turn: turnData.turn, bot: currentBot,
                 actionCard: turnData.actionCard, criteriaCard: turnData.criteriaCard,
                 action: botActions.items[turnData.action ?? 0]?.action, workerUsed: turnData.workerUsed}
           })
@@ -92,5 +92,8 @@ export default defineComponent({
 }
 p.debug, ul.debug {
   margin: 0;
+}
+td {
+  vertical-align: top;
 }
 </style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -30,25 +30,26 @@ const routes: Array<RouteRecordRaw> = [
     component: SetupBot
   },
   {
-    path: '/round/:round/turn/:turn/player/:player',
+    path: '/round/:round/turn/:turn/:turnOrderIndex?/player/:player',
     name: 'TurnPlayer',
     component: TurnPlayer
   },
   {
-    path: '/round/:round/turn/:turn/bot/:bot',
+    path: '/round/:round/turn/:turn/:turnOrderIndex?/bot/:bot',
     name: 'TurnBot',
     component: TurnBot
   },
   {
-    path: '/round/:round/turn/:turn/bot/:bot/action/:action',
+    path: '/round/:round/turn/:turn/:turnOrderIndex?/bot/:bot/action/:action',
     name: 'TurnBotAction',
     component: TurnBot
   },
   {
-    path: '/round/:round/turn/:turn/bot/:bot/action/:action/worker/:worker',
+    path: '/round/:round/turn/:turn/:turnOrderIndex?/bot/:bot/action/:action/worker/:worker',
     name: 'TurnBotActionWorker',
     component: TurnBot
   },
+  // backward compatibility end
   {
     path: '/round/:round/start',
     name: 'RoundStart',

--- a/src/services/RouteCalculator.ts
+++ b/src/services/RouteCalculator.ts
@@ -8,14 +8,16 @@ export default class RouteCalculator {
 
   readonly round : number
   readonly turn : number
+  readonly turnOrderIndex : number
   readonly action? : number
   readonly workerUsedPreviousAction? : number
   readonly player? : number
   readonly bot? : number
 
-  constructor(params:{round: number, turn?: number, action?: number, workerUsedPreviousAction?: number, player?: number, bot?: number}) {
+  constructor(params:{round: number, turn?: number, turnOrderIndex?: number, action?: number, workerUsedPreviousAction?: number, player?: number, bot?: number}) {
     this.round = params.round
     this.turn = params.turn ?? MAX_TURN  // when called in EndOfRound/EndOfGame context
+    this.turnOrderIndex = params.turnOrderIndex ?? 0
     this.action = params.action
     this.workerUsedPreviousAction = params.workerUsedPreviousAction
     this.player = params.player
@@ -49,7 +51,7 @@ export default class RouteCalculator {
    * Get route to next action ins same bot turn.
    */
   public getNextActionRouteTo(workerUsedPreviousAction? : number) : string {
-    return RouteCalculator.routeTo({round:this.round, turn:this.turn, action:(this.action ?? 0) + 1,
+    return RouteCalculator.routeTo({round:this.round, turn:this.turn, turnOrderIndex:this.turn, action:(this.action ?? 0) + 1,
         workerUsedPreviousAction:workerUsedPreviousAction ?? this.workerUsedPreviousAction, bot:this.bot})
   }
 
@@ -59,7 +61,7 @@ export default class RouteCalculator {
    */
   public getBackRouteTo(state: State) : string {
     if (this.bot && this.action && this.action > 0) {
-      return RouteCalculator.routeTo({round:this.round, turn:this.turn, action:(this.action ?? 0) - 1,
+      return RouteCalculator.routeTo({round:this.round, turn:this.turn, turnOrderIndex:this.turnOrderIndex, action:(this.action ?? 0) - 1,
           workerUsedPreviousAction:this.workerUsedPreviousAction, bot:this.bot})
     }
     const steps = getTurnOrder(state, this.round, this.turn)
@@ -104,20 +106,21 @@ export default class RouteCalculator {
     if (step.bot) {
       if (step.action && step.action > 0) {
         if (step.workerUsedPreviousAction && step.workerUsedPreviousAction > 0 && step.action > 1) {
-          return `/round/${step.round}/turn/${step.turn}/bot/${step.bot}/action/${step.action}/worker/${step.workerUsedPreviousAction}`
+          return `/round/${step.round}/turn/${step.turn}/${step.turnOrderIndex}/bot/${step.bot}/action/${step.action}/worker/${step.workerUsedPreviousAction}`
         }
-        return `/round/${step.round}/turn/${step.turn}/bot/${step.bot}/action/${step.action}`
+        return `/round/${step.round}/turn/${step.turn}/${step.turnOrderIndex}/bot/${step.bot}/action/${step.action}`
       }
-      return `/round/${step.round}/turn/${step.turn}/bot/${step.bot}`
+      return `/round/${step.round}/turn/${step.turn}/${step.turnOrderIndex}/bot/${step.bot}`
     }
-    return `/round/${step.round}/turn/${step.turn}/player/${step.player}`
+    return `/round/${step.round}/turn/${step.turn}/${step.turnOrderIndex}/player/${step.player}`
   }
 
 }
 
 interface Step {
-  readonly round?: number
-  readonly turn?: number
+  readonly round: number
+  readonly turn: number
+  readonly turnOrderIndex: number
   readonly action?: number
   readonly workerUsedPreviousAction?: number
   readonly player?: number

--- a/src/services/RouteCalculator.ts
+++ b/src/services/RouteCalculator.ts
@@ -51,7 +51,7 @@ export default class RouteCalculator {
    * Get route to next action ins same bot turn.
    */
   public getNextActionRouteTo(workerUsedPreviousAction? : number) : string {
-    return RouteCalculator.routeTo({round:this.round, turn:this.turn, turnOrderIndex:this.turn, action:(this.action ?? 0) + 1,
+    return RouteCalculator.routeTo({round:this.round, turn:this.turn, turnOrderIndex:this.turnOrderIndex, action:(this.action ?? 0) + 1,
         workerUsedPreviousAction:workerUsedPreviousAction ?? this.workerUsedPreviousAction, bot:this.bot})
   }
 

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -43,7 +43,8 @@ export const useStateStore = defineStore(`${name}.state`, {
       if (!round) {
         throw new Error(`Round ${turn.round} not found.`)
       }
-      round.turns = round.turns.filter(item => (item.turn < turn.turn) || (item.player != turn.player) || (item.bot != turn.bot))
+      round.turns = round.turns.filter(item => (item.turn < turn.turn)
+          || ((item.turn == turn.turn) && (item.player != turn.player) || (item.bot != turn.bot)))
       round.turns.push(turn)
     },
     getPlayerOrder(round: number) : PlayerOrder[] {

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -43,8 +43,7 @@ export const useStateStore = defineStore(`${name}.state`, {
       if (!round) {
         throw new Error(`Round ${turn.round} not found.`)
       }
-      round.turns = round.turns.filter(item => (item.turn < turn.turn)
-          || ((item.turn == turn.turn) && (item.player != turn.player) || (item.bot != turn.bot)))
+      round.turns = round.turns.filter(item => (item.turn < turn.turn) || (item.turn == turn.turn && item.turnOrderIndex < turn.turnOrderIndex))
       round.turns.push(turn)
     },
     getPlayerOrder(round: number) : PlayerOrder[] {
@@ -87,6 +86,7 @@ export interface PlayerOrder {
 export interface Turn {
   round: number
   turn: number
+  turnOrderIndex: number
   player?: number
   bot?: number
   cardDeck?: CardDeckPersistence

--- a/src/util/AbstractNavigationState.ts
+++ b/src/util/AbstractNavigationState.ts
@@ -11,6 +11,7 @@ export default abstract class AbstractNavigationState {
   readonly botCount : number
   readonly round : number
   readonly turn : number
+  readonly turnOrderIndex : number
   readonly botInfos : BotInfo[]
 
   constructor(route: RouteLocation, state: State) {    
@@ -21,6 +22,7 @@ export default abstract class AbstractNavigationState {
 
     this.round = getIntRouteParam(route, 'round')
     this.turn = getIntRouteParam(route, 'turn')
+    this.turnOrderIndex = getIntRouteParam(route, 'turnOrderIndex')
     this.botInfos = this.getBotInfos(route, state)
   }
 

--- a/src/util/getTurnOrder.ts
+++ b/src/util/getTurnOrder.ts
@@ -16,6 +16,7 @@ export default function getTurnOrder(state: State, currentRound: number, current
 
   let invalidTurn = false
   for (let turn=1; turn<=currentTurn+1; turn++) {
+    let turnOrderIndex = 0
     playerOrder.forEach(player => {
       const hasPassed = turns.find(item => item.turn<turn
             && item.player==player.player && item.bot==player.bot && item.passed) != undefined
@@ -25,10 +26,12 @@ export default function getTurnOrder(state: State, currentRound: number, current
           invalidTurn = true
         }
         if (player.player) {
-          steps.push({round:round.round, turn, player:player.player})
+          steps.push({round:round.round, turn, turnOrderIndex, player:player.player})
+          turnOrderIndex++
         }
         else if (player.bot) {
-          steps.push({round:round.round, turn, bot:player.bot})
+          steps.push({round:round.round, turn, turnOrderIndex, bot:player.bot})
+          turnOrderIndex++
         }
       }
     })
@@ -44,6 +47,7 @@ export default function getTurnOrder(state: State, currentRound: number, current
 export interface TurnOrder {
   readonly round: number
   readonly turn: number
+  readonly turnOrderIndex: number
   readonly player?: number
   readonly bot?: number
 }

--- a/src/views/TurnBot.vue
+++ b/src/views/TurnBot.vue
@@ -54,8 +54,8 @@ export default defineComponent({
     const state = useStateStore()
 
     const navigationState = new BotNavigationState(route, state)
-    const { botCount, round, turn, action, workerUsedPreviousAction, bot, playerColor} = navigationState
-    const routeCalculator = new RouteCalculator({round, turn, action, workerUsedPreviousAction, bot})
+    const { botCount, round, turn, turnOrderIndex, action, workerUsedPreviousAction, bot, playerColor} = navigationState
+    const routeCalculator = new RouteCalculator({round, turn, turnOrderIndex, action, workerUsedPreviousAction, bot})
 
     const workerUsed = ref(navigationState.actionItem?.workerCount ?? 0)
     const nextAction = ref(navigationState.actionItem?.nextAction ?? false)
@@ -82,6 +82,7 @@ export default defineComponent({
       this.state.storeTurn({
         round:this.round,
         turn:this.turn,
+        turnOrderIndex:this.navigationState.turnOrderIndex,
         bot:this.bot,
         cardDeck: this.navigationState.cardDeck.toPersistence(),
         workerUsed: workerUsedTotal,

--- a/src/views/TurnBot.vue
+++ b/src/views/TurnBot.vue
@@ -72,13 +72,13 @@ export default defineComponent({
   },
   methods: {
     next() : void {
-      if (this.nextAction) {
-        this.$router.push(this.routeCalculator.getNextActionRouteTo(this.workerUsed))
-        return
-      }
       const workerUsedTotal = this.workerUsed + (this.navigationState.workerUsedPreviousAction ?? 0)
       const workerLeft = this.navigationState.workerCount - workerUsedTotal
       const passed = workerLeft <= 0 ? true : undefined
+      if (this.nextAction && !passed) {
+        this.$router.push(this.routeCalculator.getNextActionRouteTo(this.workerUsed))
+        return
+      }
       this.state.storeTurn({
         round:this.round,
         turn:this.turn,

--- a/src/views/TurnBot.vue
+++ b/src/views/TurnBot.vue
@@ -19,7 +19,7 @@
   <button class="btn btn-danger btn-lg mt-4 me-2" @click="notPossible()" v-if="!isBankAction">
     {{t('turnBot.notPossible')}}
   </button>
-
+{{workerUsed}}
   <DebugInfo :navigationState="navigationState"/>
 
   <FooterButtons :backButtonRouteTo="backButtonRouteTo" endGameButtonType="abortGame"/>
@@ -73,7 +73,7 @@ export default defineComponent({
   methods: {
     next() : void {
       const workerUsedTotal = this.workerUsed + (this.navigationState.workerUsedPreviousAction ?? 0)
-      const workerLeft = this.navigationState.workerCount - workerUsedTotal
+      const workerLeft = this.navigationState.workerCount - this.workerUsed  // workerCount is already reduced by workerUsedPreviousAction
       const passed = workerLeft <= 0 ? true : undefined
       if (this.nextAction && !passed) {
         this.$router.push(this.routeCalculator.getNextActionRouteTo(this.workerUsed))

--- a/src/views/TurnPlayer.vue
+++ b/src/views/TurnPlayer.vue
@@ -66,8 +66,8 @@ export default defineComponent({
     const state = useStateStore()
 
     const navigationState = new PlayerNavigationState(route, state)
-    const { playerCount, round, turn, player, playerColor } = navigationState
-    const routeCalculator = new RouteCalculator({round, turn, player})
+    const { playerCount, round, turn, turnOrderIndex, player, playerColor } = navigationState
+    const routeCalculator = new RouteCalculator({round, turn, turnOrderIndex, player})
 
     return { t, state, playerCount, round, turn, player, playerColor, routeCalculator, navigationState }
   },
@@ -90,6 +90,7 @@ export default defineComponent({
       this.state.storeTurn({
         round:this.round,
         turn:this.turn,
+        turnOrderIndex:this.navigationState.turnOrderIndex,
         player:this.player,
         passed: passed ? true : undefined
       })

--- a/tests/unit/helper/mockTurn.ts
+++ b/tests/unit/helper/mockTurn.ts
@@ -5,12 +5,11 @@ export default function (params?: MockTurnParams) : Turn {
   return {
     round: params?.round ?? 1,
     turn: params?.turn ?? 1,
+    turnOrderIndex: params?.turnOrderIndex ?? 0,
     player: params?.player,
     bot: params?.bot,
-    botData: {
-      cardDeck: params?.cardDeck ?? CardDeck.new().toPersistence(),
-      remainingWorkers: params?.remainingWorkers ?? 0
-    },
+    cardDeck: params?.cardDeck ?? CardDeck.new().toPersistence(),
+    workerUsed: params?.workerUsed ?? 0,
     passed: params?.passed
   }
 }
@@ -18,9 +17,10 @@ export default function (params?: MockTurnParams) : Turn {
 export interface MockTurnParams {
   round? : number
   turn? : number
+  turnOrderIndex? : number
   player?: number
   bot?: number
   cardDeck?: CardDeckPersistence
-  remainingWorkers?: number
+  workerUsed?: number
   passed?: boolean
 }

--- a/tests/unit/services/RouteCalculator.spec.ts
+++ b/tests/unit/services/RouteCalculator.spec.ts
@@ -5,112 +5,114 @@ import mockState from '../helper/mockState'
 
 describe('services/RouteCalculator', () => {
   it('getNextRouteTo-round1-turn1-player', () => {
-    const routeCalculator = new RouteCalculator({round:1, turn:1, player:1})
+    const routeCalculator = new RouteCalculator({round:1, turn:1, turnOrderIndex:0, player:1})
 
     const state = mockState({playerCount:1, botCount:2, rounds:[
       mockRound({round:1, playerOrder:[{player:1},{bot:1},{bot:2}]})
     ]})
-    expect(routeCalculator.getNextRouteTo(state)).to.eq('/round/1/turn/1/bot/1')
+    expect(routeCalculator.getNextRouteTo(state)).to.eq('/round/1/turn/1/1/bot/1')
     expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/1/start')
   })
 
   it('getNextRouteTo-round1-turn1-bot1', () => {
-    const routeCalculator = new RouteCalculator({round:1, turn:1, bot:1})
+    const routeCalculator = new RouteCalculator({round:1, turn:1, turnOrderIndex:1, bot:1})
 
     const state = mockState({playerCount:1, botCount:2, rounds:[
       mockRound({round:1, playerOrder:[{player:1},{bot:1},{bot:2}]})
     ]})
-    expect(routeCalculator.getNextRouteTo(state)).to.eq('/round/1/turn/1/bot/2')
-    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/1/turn/1/player/1')
+    expect(routeCalculator.getNextRouteTo(state)).to.eq('/round/1/turn/1/2/bot/2')
+    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/1/turn/1/0/player/1')
   })
 
   it('getNextRouteTo-round1-turn1-bot1-nextAction', () => {
-    const routeCalculator = new RouteCalculator({round:1, turn:1, action:1, bot:1})
+    const routeCalculator = new RouteCalculator({round:1, turn:1, turnOrderIndex:1, action:1, bot:1})
 
     const state = mockState({playerCount:1, botCount:2, rounds:[
       mockRound({round:1, playerOrder:[{player:1},{bot:1},{bot:2}]})
     ]})
-    expect(routeCalculator.getNextActionRouteTo()).to.eq('/round/1/turn/1/bot/1/action/2')
-    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/1/turn/1/bot/1')
+    expect(routeCalculator.getNextActionRouteTo()).to.eq('/round/1/turn/1/1/bot/1/action/2')
+    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/1/turn/1/1/bot/1')
   })
 
   it('getNextRouteTo-round1-turn1-bot1-nextAction-workerUsedPreviousAction', () => {
-    const routeCalculator = new RouteCalculator({round:1, turn:1, action:3, workerUsedPreviousAction:1, bot:1})
+    const routeCalculator = new RouteCalculator({round:1, turn:1, turnOrderIndex:1, action:3, workerUsedPreviousAction:1, bot:1})
 
     const state = mockState({playerCount:1, botCount:2, rounds:[
       mockRound({round:1, playerOrder:[{player:1},{bot:1},{bot:2}]})
     ]})
-    expect(routeCalculator.getNextActionRouteTo()).to.eq('/round/1/turn/1/bot/1/action/4/worker/1')
-    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/1/turn/1/bot/1/action/2/worker/1')
+    expect(routeCalculator.getNextActionRouteTo()).to.eq('/round/1/turn/1/1/bot/1/action/4/worker/1')
+    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/1/turn/1/1/bot/1/action/2/worker/1')
   })
 
   it('getNextRouteTo-round1-turn1-bot1-nextAction-workerUsedPreviousAction-action2', () => {
-    const routeCalculator = new RouteCalculator({round:1, turn:1, action:2, workerUsedPreviousAction:1, bot:1})
+    const routeCalculator = new RouteCalculator({round:1, turn:1, turnOrderIndex:1, action:2, workerUsedPreviousAction:1, bot:1})
 
     const state = mockState({playerCount:1, botCount:2, rounds:[
       mockRound({round:1, playerOrder:[{player:1},{bot:1},{bot:2}]})
     ]})
-    expect(routeCalculator.getNextActionRouteTo()).to.eq('/round/1/turn/1/bot/1/action/3/worker/1')
+    expect(routeCalculator.getNextActionRouteTo()).to.eq('/round/1/turn/1/1/bot/1/action/3/worker/1')
     // no workerUsedPreviousAction because action 1 may be the special "nextAction" action
-    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/1/turn/1/bot/1/action/1')
+    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/1/turn/1/1/bot/1/action/1')
   })
 
   it('getNextRouteTo_round1-turn1-bot2', () => {
-    const routeCalculator = new RouteCalculator({round:1, turn:1, bot:2})
+    const routeCalculator = new RouteCalculator({round:1, turn:1, turnOrderIndex:2, bot:2})
     
     const state = mockState({playerCount:1, botCount:2, rounds:[
       mockRound({round:1, playerOrder:[{player:1},{bot:1},{bot:2}]})
     ]})
-    expect(routeCalculator.getNextRouteTo(state)).to.eq('/round/1/turn/2/player/1')
-    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/1/turn/1/bot/1')
+    expect(routeCalculator.getNextRouteTo(state)).to.eq('/round/1/turn/2/0/player/1')
+    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/1/turn/1/1/bot/1')
   })
 
   it('getNextRouteTo_round1-turn1-bot2-playerpassed', () => {
-    const routeCalculator = new RouteCalculator({round:1, turn:1, bot:2})
+    const routeCalculator = new RouteCalculator({round:1, turn:1, turnOrderIndex:2, bot:2})
 
     const state = mockState({playerCount:1, botCount:2, rounds:[
-      mockRound({round:1, playerOrder:[{player:1},{bot:1},{bot:2}], turns:[{round:1, turn:1, player:1, passed:true}]})
+      mockRound({round:1, playerOrder:[{player:1},{bot:1},{bot:2}], turns:[
+        {round:1, turn:1, turnOrderIndex:0, player:1, passed:true}
+      ]})
     ]})
-    expect(routeCalculator.getNextRouteTo(state)).to.eq('/round/1/turn/2/bot/1')
-    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/1/turn/1/bot/1')
+    expect(routeCalculator.getNextRouteTo(state)).to.eq('/round/1/turn/2/0/bot/1')
+    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/1/turn/1/1/bot/1')
   })
 
   it('getNextRouteTo_round1-turn1-bot2-playerpassed-bot1passed', () => {
-    const routeCalculator = new RouteCalculator({round:1, turn:1, bot:2})
+    const routeCalculator = new RouteCalculator({round:1, turn:1, turnOrderIndex:2, bot:2})
 
     const state = mockState({playerCount:1, botCount:2, rounds:[
       mockRound({round:1, playerOrder:[{player:1},{bot:1},{bot:2}], turns:[
-        {round:1, turn:1, player:1, passed:true},
-        {round:1, turn:1, bot:1, passed:true}]})
+        {round:1, turn:1, turnOrderIndex:0, player:1, passed:true},
+        {round:1, turn:1, turnOrderIndex:1, bot:1, passed:true}]})
     ]})
-    expect(routeCalculator.getNextRouteTo(state)).to.eq('/round/1/turn/2/bot/2')
-    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/1/turn/1/bot/1')
+    expect(routeCalculator.getNextRouteTo(state)).to.eq('/round/1/turn/2/0/bot/2')
+    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/1/turn/1/1/bot/1')
   })
 
   it('getNextRouteTo_round1-turn1-bot2-playerpassed-bot1passed-bot2passed', () => {
-    const routeCalculator = new RouteCalculator({round:1, turn:1, bot:2})
+    const routeCalculator = new RouteCalculator({round:1, turn:1, turnOrderIndex:2, bot:2})
 
     const state = mockState({playerCount:1, botCount:2, rounds:[
       mockRound({round:1, playerOrder:[{player:1},{bot:1},{bot:2}], turns:[
-        {round:1, turn:1, player:1, passed:true},
-        {round:1, turn:1, bot:1, passed:true},
-        {round:1, turn:1, bot:2, passed:true}]})
+        {round:1, turn:1, turnOrderIndex:0, player:1, passed:true},
+        {round:1, turn:1, turnOrderIndex:1, bot:1, passed:true},
+        {round:1, turn:1, turnOrderIndex:2, bot:2, passed:true}]})
     ]})
     expect(routeCalculator.getNextRouteTo(state)).to.eq('/round/1/end')
-    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/1/turn/1/bot/1')
+    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/1/turn/1/1/bot/1')
   })
 
   it('getNextRouteTo_round7-turn1-bot2-playerpassed-bot1passed-bot2passed', () => {
-    const routeCalculator = new RouteCalculator({round:7, turn:1, bot:2})
+    const routeCalculator = new RouteCalculator({round:7, turn:1, turnOrderIndex:2, bot:2})
 
     const state = mockState({playerCount:1, botCount:2, rounds:[
       mockRound({round:7, playerOrder:[{player:1},{bot:1},{bot:2}], turns:[
-        {round:7, turn:1, player:1, passed:true},
-        {round:7, turn:1, bot:1, passed:true},
-        {round:7, turn:1, bot:2, passed:true}]})
+        {round:7, turn:1, turnOrderIndex:0, player:1, passed:true},
+        {round:7, turn:1, turnOrderIndex:1, bot:1, passed:true},
+        {round:7, turn:1, turnOrderIndex:2, bot:2, passed:true}]})
     ]})
     expect(routeCalculator.getNextRouteTo(state)).to.eq('/endOfGame')
-    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/7/turn/1/bot/1')
+    expect(routeCalculator.getBackRouteTo(state)).to.eq('/round/7/turn/1/1/bot/1')
   })
 
   it('getFirstTurnRouteTo', () => {
@@ -119,7 +121,7 @@ describe('services/RouteCalculator', () => {
     const state = mockState({playerCount:1, botCount:2, rounds:[
       mockRound({round:1, playerOrder:[{player:1},{bot:1},{bot:2}]})
     ]})
-    expect(routeCalculator.getFirstTurnRouteTo(state)).to.eq('/round/1/turn/1/player/1')
+    expect(routeCalculator.getFirstTurnRouteTo(state)).to.eq('/round/1/turn/1/0/player/1')
   })
 
   it('getLastTurnRouteTo', () => {
@@ -127,11 +129,11 @@ describe('services/RouteCalculator', () => {
 
     const state = mockState({playerCount:1, botCount:2, rounds:[
       mockRound({round:1, playerOrder:[{player:1},{bot:1},{bot:2}], turns:[
-        {round:1, turn:1, player:1, passed:true},
-        {round:1, turn:1, bot:1, passed:true},
-        {round:1, turn:1, bot:2, passed:true}]})
+        {round:1, turn:1, turnOrderIndex:0, player:1, passed:true},
+        {round:1, turn:1, turnOrderIndex:1, bot:1, passed:true},
+        {round:1, turn:1, turnOrderIndex:2, bot:2, passed:true}]})
   ]})
-    expect(routeCalculator.getLastTurnRouteTo(state)).to.eq('/round/1/turn/1/bot/2')
+    expect(routeCalculator.getLastTurnRouteTo(state)).to.eq('/round/1/turn/1/2/bot/2')
   })
 
   it('getLastTurnRouteTo-empty', () => {

--- a/tests/unit/util/getTurnOrder.spec.ts
+++ b/tests/unit/util/getTurnOrder.spec.ts
@@ -9,60 +9,60 @@ describe('util/getTurnOrder', () => {
       mockRound({round:1, playerOrder:[{player:1},{bot:1},{bot:2}]})]}
     )
     expect(getTurnOrder(state, 1, 2)).to.eql([
-      {round:1, turn:1, player:1},
-      {round:1, turn:1, bot:1},
-      {round:1, turn:1, bot:2},
-      {round:1, turn:2, player:1},
-      {round:1, turn:2, bot:1},
-      {round:1, turn:2, bot:2},
-      {round:1, turn:3, player:1},
-      {round:1, turn:3, bot:1},
-      {round:1, turn:3, bot:2}
+      {round:1, turn:1, turnOrderIndex: 0, player:1},
+      {round:1, turn:1, turnOrderIndex: 1, bot:1},
+      {round:1, turn:1, turnOrderIndex: 2, bot:2},
+      {round:1, turn:2, turnOrderIndex: 0, player:1},
+      {round:1, turn:2, turnOrderIndex: 1, bot:1},
+      {round:1, turn:2, turnOrderIndex: 2, bot:2},
+      {round:1, turn:3, turnOrderIndex: 0, player:1},
+      {round:1, turn:3, turnOrderIndex: 1, bot:1},
+      {round:1, turn:3, turnOrderIndex: 2, bot:2}
     ])
   })
 
   it('round1-turn2-passed', () => {
     const state = mockState({playerCount:1, botCount:2, rounds:[
       mockRound({round:1, playerOrder:[{player:1},{bot:1},{bot:2}], turns:[
-        {round:1,turn:1,player:1},
-        {round:1,turn:1,bot:1,passed:true},
-        {round:1,turn:1,bot:2},
-        {round:1,turn:2,player:1,passed:true},
-        {round:1,turn:2,bot:2}
+        {round:1,turn:1,turnOrderIndex:0,player:1},
+        {round:1,turn:1,turnOrderIndex:1,bot:1,passed:true},
+        {round:1,turn:1,turnOrderIndex:2,bot:2},
+        {round:1,turn:2,turnOrderIndex:0,player:1,passed:true},
+        {round:1,turn:2,turnOrderIndex:1,bot:2}
       ]})
     ]})
     expect(getTurnOrder(state, 1, 2)).to.eql([
-      {round:1, turn:1, player:1},
-      {round:1, turn:1, bot:1},
-      {round:1, turn:1, bot:2},
-      {round:1, turn:2, player:1},
-      {round:1, turn:2, bot:2},
-      {round:1, turn:3, bot:2}
+      {round:1, turn:1, turnOrderIndex:0, player:1},
+      {round:1, turn:1, turnOrderIndex:1, bot:1},
+      {round:1, turn:1, turnOrderIndex:2, bot:2},
+      {round:1, turn:2, turnOrderIndex:0, player:1},
+      {round:1, turn:2, turnOrderIndex:1, bot:2},
+      {round:1, turn:3, turnOrderIndex:0, bot:2}
     ])
   })
 
   it('round1-turn2-passed-playerorder', () => {
     const state = mockState({playerCount:2, botCount:2, rounds:[
       mockRound({round:1, playerOrder:[{player:2},{bot:1},{bot:2},{player:1}], turns:[
-        {round:1,turn:1,player:2},
-        {round:1,turn:1,bot:1,passed:true},
-        {round:1,turn:1,bot:2},
-        {round:1,turn:1,player:1},
-        {round:1,turn:2,player:2},
-        {round:1,turn:2,bot:2},
-        {round:1,turn:2,player:1,passed:true}
+        {round:1,turn:1,turnOrderIndex:0,player:2},
+        {round:1,turn:1,turnOrderIndex:1,bot:1,passed:true},
+        {round:1,turn:1,turnOrderIndex:2,bot:2},
+        {round:1,turn:1,turnOrderIndex:3,player:1},
+        {round:1,turn:2,turnOrderIndex:0,player:2},
+        {round:1,turn:2,turnOrderIndex:1,bot:2},
+        {round:1,turn:2,turnOrderIndex:2,player:1,passed:true}
       ]})
     ]})
     expect(getTurnOrder(state, 1, 2)).to.eql([
-      {round:1, turn:1, player:2},
-      {round:1, turn:1, bot:1},
-      {round:1, turn:1, bot:2},
-      {round:1, turn:1, player:1},
-      {round:1, turn:2, player:2},
-      {round:1, turn:2, bot:2},
-      {round:1, turn:2, player:1},
-      {round:1, turn:3, player:2},
-      {round:1, turn:3, bot:2}
+      {round:1, turn:1, turnOrderIndex:0, player:2},
+      {round:1, turn:1, turnOrderIndex:1, bot:1},
+      {round:1, turn:1, turnOrderIndex:2, bot:2},
+      {round:1, turn:1, turnOrderIndex:3, player:1},
+      {round:1, turn:2, turnOrderIndex:0, player:2},
+      {round:1, turn:2, turnOrderIndex:1, bot:2},
+      {round:1, turn:2, turnOrderIndex:2, player:1},
+      {round:1, turn:3, turnOrderIndex:0, player:2},
+      {round:1, turn:3, turnOrderIndex:1, bot:2}
     ])
   })
 })


### PR DESCRIPTION
esp. pass behavior in the last turn
introduce turnOrderIndex URL parameter to ensure erasing correct turn steps when going back and forth in navigation history